### PR TITLE
Experiment: support isinstance(ugettext_lazy(), unicode)

### DIFF
--- a/django/urls/resolvers.py
+++ b/django/urls/resolvers.py
@@ -19,7 +19,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.utils import lru_cache, six
 from django.utils.datastructures import MultiValueDict
 from django.utils.encoding import force_str, force_text
-from django.utils.functional import cached_property
+from django.utils.functional import cached_property, Promise
 from django.utils.http import RFC3986_SUBDELIMS, urlquote
 from django.utils.regex_helper import normalize
 from django.utils.translation import get_language
@@ -98,7 +98,8 @@ class LocaleRegexProvider(object):
         """
         language_code = get_language()
         if language_code not in self._regex_dict:
-            regex = self._regex if isinstance(self._regex, six.string_types) else force_text(self._regex)
+            regex = self._regex if (isinstance(self._regex, six.string_types)
+                                    and not isinstance(self._regex, Promise)) else force_text(self._regex)
             try:
                 compiled_regex = re.compile(regex, re.UNICODE)
             except re.error as e:

--- a/django/utils/functional.py
+++ b/django/utils/functional.py
@@ -132,6 +132,11 @@ def lazy(func, *resultclasses):
             else:
                 return func(*self.__args, **self.__kw)
 
+        @property
+        def __class__(self):
+            # proxy __class__ to make isinstance(lazy_result, resultclass) work
+            return self.__cast().__class__
+
         def __str__(self):
             # object defines __str__(), so __prepare_class__() won't overload
             # a __str__() method from the proxied class.

--- a/tests/i18n/tests.py
+++ b/tests/i18n/tests.py
@@ -26,6 +26,7 @@ from django.utils.formats import (
     date_format, get_format, get_format_modules, iter_format_modules, localize,
     localize_input, reset_format_cache, sanitize_separators, time_format,
 )
+from django.utils.functional import Promise
 from django.utils.numberformat import format as nformat
 from django.utils.safestring import SafeBytes, SafeString, SafeText, mark_safe
 from django.utils.six import PY3
@@ -178,6 +179,16 @@ class TranslationTests(SimpleTestCase):
         self.assertEqual(six.text_type(s1), "test")
         s2 = pickle.loads(pickle.dumps(s1))
         self.assertEqual(six.text_type(s2), "test")
+
+    def test_lazy_instanceof_text(self):
+        s1 = ugettext_lazy("test")
+        self.assertIsInstance(s1, six.text_type)
+        self.assertIsInstance(s1, Promise)  # recommended way to identify lazy result
+
+        # Real-world cases:
+        from six.moves.urllib.parse import urlencode
+        self.assertEqual(urlencode({'t': ugettext_lazy("scrúdú")}), "t=scr%C3%BAd%C3%BA")
+        self.assertEqual(urlencode({'t': ugettext_lazy("test")}, doseq=True), "t=test")
 
     @override_settings(LOCALE_PATHS=extended_locale_paths)
     def test_ungettext_lazy(self):

--- a/tests/utils_tests/test_functional.py
+++ b/tests/utils_tests/test_functional.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 import unittest
 
 from django.utils import six
-from django.utils.functional import cached_property, lazy, lazy_property
+from django.utils.functional import cached_property, lazy, lazy_property, Promise
 
 
 class FunctionalTestCase(unittest.TestCase):
@@ -145,3 +145,9 @@ class FunctionalTestCase(unittest.TestCase):
         original_object = b'J\xc3\xbcst a str\xc3\xadng'
         lazy_obj = lazy(lambda: original_object, bytes)
         self.assertEqual(repr(original_object), repr(lazy_obj()))
+
+    def test_lazy_instanceof(self):
+        original_object = 'Lazy translation text'
+        lazy_obj = lazy(lambda: original_object, six.text_type)
+        self.assertIsInstance(lazy_obj(), six.text_type)
+        self.assertIsInstance(lazy_obj(), Promise)  # recommended way to identify lazy result


### PR DESCRIPTION
**NOT FOR MERGE**

Proxy `__class__` property on lazy function result to support isinstance.

See discussion in
https://groups.google.com/forum/#!topic/django-developers/eFsGf1ZrG7c
