### PR TITLE
Ticket 35581: Updated django.core.mail to Python's modern email API [WIP, DO-NOT-MERGE]

### DIFF
--- a/django/core/mail/_deprecated.py
+++ b/django/core/mail/_deprecated.py
@@ -1,0 +1,200 @@
+# RemovedInDjango61Warning: This entire file.
+import warnings
+from email import charset as Charset
+from email import generator
+from email.errors import HeaderParseError
+from email.header import Header
+from email.headerregistry import Address, parser
+from email.mime.message import MIMEMessage
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from email.utils import formataddr, getaddresses
+from io import BytesIO, StringIO
+
+from django.conf import settings
+from django.utils.deprecation import RemovedInDjango61Warning
+from django.utils.encoding import force_str, punycode
+
+# Don't BASE64-encode UTF-8 messages so that we avoid unwanted attention from
+# some spam filters.
+utf8_charset = Charset.Charset("utf-8")
+utf8_charset.body_encoding = None  # Python defaults to BASE64
+utf8_charset_qp = Charset.Charset("utf-8")
+utf8_charset_qp.body_encoding = Charset.QP
+
+RFC5322_EMAIL_LINE_LENGTH_LIMIT = 998
+
+
+# BadHeaderError must _be_ ValueError (not subclass it), so that existing code
+# with `except BadHeaderError` will catch the ValueError that Python's modern
+# email API raises for headers containing CR or NL.
+BadHeaderError = ValueError
+
+# Header names that contain structured address data (RFC 5322).
+ADDRESS_HEADERS = {
+    "from",
+    "sender",
+    "reply-to",
+    "to",
+    "cc",
+    "bcc",
+    "resent-from",
+    "resent-sender",
+    "resent-to",
+    "resent-cc",
+    "resent-bcc",
+}
+
+
+def forbid_multi_line_headers(name, val, encoding):
+    """Forbid multi-line headers to prevent header injection."""
+    warnings.warn(
+        "The internal API forbid_multi_line_headers() is deprecated."
+        " Python's modern email API (with email.message.EmailMessage or"
+        " email.policy.default) will reject multi-line headers.",
+        RemovedInDjango61Warning,
+    )
+
+    encoding = encoding or settings.DEFAULT_CHARSET
+    val = str(val)  # val may be lazy
+    if "\n" in val or "\r" in val:
+        raise BadHeaderError(
+            "Header values can't contain newlines (got %r for header %r)" % (val, name)
+        )
+    try:
+        val.encode("ascii")
+    except UnicodeEncodeError:
+        if name.lower() in ADDRESS_HEADERS:
+            val = ", ".join(
+                sanitize_address(addr, encoding) for addr in getaddresses((val,))
+            )
+        else:
+            val = Header(val, encoding).encode()
+    else:
+        if name.lower() == "subject":
+            val = Header(val).encode()
+    return name, val
+
+
+def sanitize_address(addr, encoding):
+    """
+    Format a pair of (name, address) or an email address string.
+    """
+    warnings.warn(
+        "The internal API sanitize_address() is deprecated."
+        " Python's modern email API (with email.message.EmailMessage or"
+        " email.policy.default) will handle most required validation and"
+        " encoding. Use Python's email.headerregistry.Address to construct"
+        " formatted addresses from component parts.",
+        RemovedInDjango61Warning,
+    )
+
+    address = None
+    if not isinstance(addr, tuple):
+        addr = force_str(addr)
+        try:
+            token, rest = parser.get_mailbox(addr)
+        except (HeaderParseError, ValueError, IndexError):
+            raise ValueError('Invalid address "%s"' % addr)
+        else:
+            if rest:
+                # The entire email address must be parsed.
+                raise ValueError(
+                    'Invalid address; only %s could be parsed from "%s"' % (token, addr)
+                )
+            nm = token.display_name or ""
+            localpart = token.local_part
+            domain = token.domain or ""
+    else:
+        nm, address = addr
+        if "@" not in address:
+            raise ValueError(f'Invalid address "{address}"')
+        localpart, domain = address.rsplit("@", 1)
+
+    address_parts = nm + localpart + domain
+    if "\n" in address_parts or "\r" in address_parts:
+        raise ValueError("Invalid address; address parts cannot contain newlines.")
+
+    # Avoid UTF-8 encode, if it's possible.
+    try:
+        nm.encode("ascii")
+        nm = Header(nm).encode()
+    except UnicodeEncodeError:
+        nm = Header(nm, encoding).encode()
+    try:
+        localpart.encode("ascii")
+    except UnicodeEncodeError:
+        localpart = Header(localpart, encoding).encode()
+    domain = punycode(domain)
+
+    parsed_address = Address(username=localpart, domain=domain)
+    return formataddr((nm, parsed_address.addr_spec))
+
+
+class MIMEMixin:
+    def as_string(self, unixfrom=False, linesep="\n"):
+        """Return the entire formatted message as a string.
+        Optional `unixfrom' when True, means include the Unix From_ envelope
+        header.
+
+        This overrides the default as_string() implementation to not mangle
+        lines that begin with 'From '. See bug #13433 for details.
+        """
+        fp = StringIO()
+        g = generator.Generator(fp, mangle_from_=False)
+        g.flatten(self, unixfrom=unixfrom, linesep=linesep)
+        return fp.getvalue()
+
+    def as_bytes(self, unixfrom=False, linesep="\n"):
+        """Return the entire formatted message as bytes.
+        Optional `unixfrom' when True, means include the Unix From_ envelope
+        header.
+
+        This overrides the default as_bytes() implementation to not mangle
+        lines that begin with 'From '. See bug #13433 for details.
+        """
+        fp = BytesIO()
+        g = generator.BytesGenerator(fp, mangle_from_=False)
+        g.flatten(self, unixfrom=unixfrom, linesep=linesep)
+        return fp.getvalue()
+
+
+class SafeMIMEMessage(MIMEMixin, MIMEMessage):
+    def __setitem__(self, name, val):
+        # message/rfc822 attachments must be ASCII
+        name, val = forbid_multi_line_headers(name, val, "ascii")
+        MIMEMessage.__setitem__(self, name, val)
+
+
+class SafeMIMEText(MIMEMixin, MIMEText):
+    def __init__(self, _text, _subtype="plain", _charset=None):
+        self.encoding = _charset
+        MIMEText.__init__(self, _text, _subtype=_subtype, _charset=_charset)
+
+    def __setitem__(self, name, val):
+        name, val = forbid_multi_line_headers(name, val, self.encoding)
+        MIMEText.__setitem__(self, name, val)
+
+    def set_payload(self, payload, charset=None):
+        if charset == "utf-8" and not isinstance(charset, Charset.Charset):
+            has_long_lines = any(
+                len(line.encode(errors="surrogateescape"))
+                > RFC5322_EMAIL_LINE_LENGTH_LIMIT
+                for line in payload.splitlines()
+            )
+            # Quoted-Printable encoding has the side effect of shortening long
+            # lines, if any (#22561).
+            charset = utf8_charset_qp if has_long_lines else utf8_charset
+        MIMEText.set_payload(self, payload, charset=charset)
+
+
+class SafeMIMEMultipart(MIMEMixin, MIMEMultipart):
+    def __init__(
+        self, _subtype="mixed", boundary=None, _subparts=None, encoding=None, **_params
+    ):
+        self.encoding = encoding
+        MIMEMultipart.__init__(self, _subtype, boundary, _subparts, **_params)
+
+    def __setitem__(self, name, val):
+        name, val = forbid_multi_line_headers(name, val, self.encoding)
+        MIMEMultipart.__setitem__(self, name, val)

--- a/django/core/mail/backends/smtp.py
+++ b/django/core/mail/backends/smtp.py
@@ -1,13 +1,16 @@
 """SMTP email backend class."""
 
+import email.policy
 import smtplib
 import ssl
 import threading
+from email.errors import HeaderParseError
+from email.headerregistry import Address, AddressHeader
 
 from django.conf import settings
 from django.core.mail.backends.base import BaseEmailBackend
-from django.core.mail.message import sanitize_address
 from django.core.mail.utils import DNS_NAME
+from django.utils.encoding import force_str, punycode
 from django.utils.functional import cached_property
 
 
@@ -145,18 +148,53 @@ class EmailBackend(BaseEmailBackend):
         """A helper method that does the actual sending."""
         if not email_message.recipients():
             return False
-        encoding = email_message.encoding or settings.DEFAULT_CHARSET
-        from_email = sanitize_address(email_message.from_email, encoding)
-        recipients = [
-            sanitize_address(addr, encoding) for addr in email_message.recipients()
-        ]
-        message = email_message.message()
+        from_email = self._prep_address(email_message.from_email)
+        recipients = [self._prep_address(addr) for addr in email_message.recipients()]
+        message = email_message.message(policy=email.policy.SMTP)
         try:
-            self.connection.sendmail(
-                from_email, recipients, message.as_bytes(linesep="\r\n")
-            )
+            self.connection.sendmail(from_email, recipients, message.as_bytes())
         except smtplib.SMTPException:
             if not self.fail_silently:
                 raise
             return False
         return True
+
+    def _prep_address(self, address, utf8=False):
+        """
+        Return the addr-spec portion of an email address, with IDNA encoding
+        applied to non-ASCII domains when enabled. Raises ValueError for invalid
+        addresses, including CR/NL injection.
+
+        If utf8 is True, process the address for sending with the SMTPUTF8
+        extension. Otherwise, force ASCII encoding and raise ValueError if
+        that isn't possible (e.g., non-ASCII local-part).
+        """
+        # (This is the subset of the old django.mail.message.sanitize_address()
+        # necessary for the SMTP protocol.)
+        address = force_str(address)
+        try:
+            parsed = AddressHeader.value_parser(address)
+        except (AssertionError, HeaderParseError, IndexError, TypeError, ValueError):
+            # (Don't include the parser error message. It's generally not helpful.)
+            raise ValueError(f"Invalid address {address!r}") from None
+        else:
+            defects = set(str(defect) for defect in parsed.all_defects)
+            # Local mailboxes like "From: webmaster" are allowed (#15042).
+            defects.discard("addr-spec local part with no domain")
+            # Non-ASCII local-part is allowed with SMTPUTF8.
+            if utf8:
+                defects.discard("local-part contains non-ASCII characters")
+            if defects:
+                raise ValueError(f"Invalid address {address!r}: {'; '.join(defects)}")
+
+        mailboxes = parsed.all_mailboxes
+        if len(mailboxes) != 1:
+            raise ValueError(f"Invalid address {address!r}: must be a single address")
+
+        mailbox = mailboxes[0]
+        if utf8 or mailbox.domain is None or mailbox.domain.isascii():
+            return mailbox.addr_spec
+        else:
+            # Re-compose an addr-spec with the IDNA encoded domain.
+            domain = punycode(mailbox.domain)
+            return str(Address(username=mailbox.local_part, domain=domain))

--- a/django/core/mail/message.py
+++ b/django/core/mail/message.py
@@ -1,195 +1,27 @@
+import email.message
+import email.policy
 import mimetypes
+import warnings
 from collections import namedtuple
-from email import charset as Charset
-from email import encoders as Encoders
-from email import generator, message_from_string
-from email.errors import HeaderParseError
-from email.header import Header
-from email.headerregistry import Address, parser
-from email.message import Message
+from datetime import datetime, timezone
+from email.headerregistry import Address, AddressHeader
 from email.mime.base import MIMEBase
-from email.mime.message import MIMEMessage
-from email.mime.multipart import MIMEMultipart
-from email.mime.text import MIMEText
-from email.utils import formataddr, formatdate, getaddresses, make_msgid
-from io import BytesIO, StringIO
+from email.utils import make_msgid
 from pathlib import Path
 
 from django.conf import settings
+from django.core.mail._deprecated import (  # NOQA: F401; RemovedInDjango61Warning
+    forbid_multi_line_headers,
+    sanitize_address,
+)
 from django.core.mail.utils import DNS_NAME
-from django.utils.encoding import force_str, punycode
-
-# Don't BASE64-encode UTF-8 messages so that we avoid unwanted attention from
-# some spam filters.
-utf8_charset = Charset.Charset("utf-8")
-utf8_charset.body_encoding = None  # Python defaults to BASE64
-utf8_charset_qp = Charset.Charset("utf-8")
-utf8_charset_qp.body_encoding = Charset.QP
+from django.utils.deprecation import RemovedInDjango61Warning
+from django.utils.encoding import force_bytes, force_str, punycode
+from django.utils.timezone import get_current_timezone
 
 # Default MIME type to use on attachments (if it is not explicitly given
 # and cannot be guessed).
 DEFAULT_ATTACHMENT_MIME_TYPE = "application/octet-stream"
-
-RFC5322_EMAIL_LINE_LENGTH_LIMIT = 998
-
-
-class BadHeaderError(ValueError):
-    pass
-
-
-# Header names that contain structured address data (RFC 5322).
-ADDRESS_HEADERS = {
-    "from",
-    "sender",
-    "reply-to",
-    "to",
-    "cc",
-    "bcc",
-    "resent-from",
-    "resent-sender",
-    "resent-to",
-    "resent-cc",
-    "resent-bcc",
-}
-
-
-def forbid_multi_line_headers(name, val, encoding):
-    """Forbid multi-line headers to prevent header injection."""
-    encoding = encoding or settings.DEFAULT_CHARSET
-    val = str(val)  # val may be lazy
-    if "\n" in val or "\r" in val:
-        raise BadHeaderError(
-            "Header values can't contain newlines (got %r for header %r)" % (val, name)
-        )
-    try:
-        val.encode("ascii")
-    except UnicodeEncodeError:
-        if name.lower() in ADDRESS_HEADERS:
-            val = ", ".join(
-                sanitize_address(addr, encoding) for addr in getaddresses((val,))
-            )
-        else:
-            val = Header(val, encoding).encode()
-    else:
-        if name.lower() == "subject":
-            val = Header(val).encode()
-    return name, val
-
-
-def sanitize_address(addr, encoding):
-    """
-    Format a pair of (name, address) or an email address string.
-    """
-    address = None
-    if not isinstance(addr, tuple):
-        addr = force_str(addr)
-        try:
-            token, rest = parser.get_mailbox(addr)
-        except (HeaderParseError, ValueError, IndexError):
-            raise ValueError('Invalid address "%s"' % addr)
-        else:
-            if rest:
-                # The entire email address must be parsed.
-                raise ValueError(
-                    'Invalid address; only %s could be parsed from "%s"' % (token, addr)
-                )
-            nm = token.display_name or ""
-            localpart = token.local_part
-            domain = token.domain or ""
-    else:
-        nm, address = addr
-        if "@" not in address:
-            raise ValueError(f'Invalid address "{address}"')
-        localpart, domain = address.rsplit("@", 1)
-
-    address_parts = nm + localpart + domain
-    if "\n" in address_parts or "\r" in address_parts:
-        raise ValueError("Invalid address; address parts cannot contain newlines.")
-
-    # Avoid UTF-8 encode, if it's possible.
-    try:
-        nm.encode("ascii")
-        nm = Header(nm).encode()
-    except UnicodeEncodeError:
-        nm = Header(nm, encoding).encode()
-    try:
-        localpart.encode("ascii")
-    except UnicodeEncodeError:
-        localpart = Header(localpart, encoding).encode()
-    domain = punycode(domain)
-
-    parsed_address = Address(username=localpart, domain=domain)
-    return formataddr((nm, parsed_address.addr_spec))
-
-
-class MIMEMixin:
-    def as_string(self, unixfrom=False, linesep="\n"):
-        """Return the entire formatted message as a string.
-        Optional `unixfrom' when True, means include the Unix From_ envelope
-        header.
-
-        This overrides the default as_string() implementation to not mangle
-        lines that begin with 'From '. See bug #13433 for details.
-        """
-        fp = StringIO()
-        g = generator.Generator(fp, mangle_from_=False)
-        g.flatten(self, unixfrom=unixfrom, linesep=linesep)
-        return fp.getvalue()
-
-    def as_bytes(self, unixfrom=False, linesep="\n"):
-        """Return the entire formatted message as bytes.
-        Optional `unixfrom' when True, means include the Unix From_ envelope
-        header.
-
-        This overrides the default as_bytes() implementation to not mangle
-        lines that begin with 'From '. See bug #13433 for details.
-        """
-        fp = BytesIO()
-        g = generator.BytesGenerator(fp, mangle_from_=False)
-        g.flatten(self, unixfrom=unixfrom, linesep=linesep)
-        return fp.getvalue()
-
-
-class SafeMIMEMessage(MIMEMixin, MIMEMessage):
-    def __setitem__(self, name, val):
-        # message/rfc822 attachments must be ASCII
-        name, val = forbid_multi_line_headers(name, val, "ascii")
-        MIMEMessage.__setitem__(self, name, val)
-
-
-class SafeMIMEText(MIMEMixin, MIMEText):
-    def __init__(self, _text, _subtype="plain", _charset=None):
-        self.encoding = _charset
-        MIMEText.__init__(self, _text, _subtype=_subtype, _charset=_charset)
-
-    def __setitem__(self, name, val):
-        name, val = forbid_multi_line_headers(name, val, self.encoding)
-        MIMEText.__setitem__(self, name, val)
-
-    def set_payload(self, payload, charset=None):
-        if charset == "utf-8" and not isinstance(charset, Charset.Charset):
-            has_long_lines = any(
-                len(line.encode(errors="surrogateescape"))
-                > RFC5322_EMAIL_LINE_LENGTH_LIMIT
-                for line in payload.splitlines()
-            )
-            # Quoted-Printable encoding has the side effect of shortening long
-            # lines, if any (#22561).
-            charset = utf8_charset_qp if has_long_lines else utf8_charset
-        MIMEText.set_payload(self, payload, charset=charset)
-
-
-class SafeMIMEMultipart(MIMEMixin, MIMEMultipart):
-    def __init__(
-        self, _subtype="mixed", boundary=None, _subparts=None, encoding=None, **_params
-    ):
-        self.encoding = encoding
-        MIMEMultipart.__init__(self, _subtype, boundary, _subparts, **_params)
-
-    def __setitem__(self, name, val):
-        name, val = forbid_multi_line_headers(name, val, self.encoding)
-        MIMEMultipart.__setitem__(self, name, val)
-
 
 EmailAlternative = namedtuple("Alternative", ["content", "mimetype"])
 EmailAttachment = namedtuple("Attachment", ["filename", "content", "mimetype"])
@@ -199,7 +31,10 @@ class EmailMessage:
     """A container for email information."""
 
     content_subtype = "plain"
-    mixed_subtype = "mixed"
+
+    # Undocumented charset to use for text/* message bodies
+    # and attachments. Defaults to settings.DEFAULT_CHARSET.
+    # (Should rename to `charset` if it will be documented.)
     encoding = None  # None => use settings default
 
     def __init__(
@@ -249,7 +84,8 @@ class EmailMessage:
         self.attachments = []
         if attachments:
             for attachment in attachments:
-                if isinstance(attachment, MIMEBase):
+                # RemovedInDjango61Warning: MIMEBase attachment support.
+                if isinstance(attachment, (MIMEBase, email.message.MIMEPart)):
                     self.attach(attachment)
                 else:
                     self.attach(*attachment)
@@ -263,12 +99,13 @@ class EmailMessage:
             self.connection = get_connection(fail_silently=fail_silently)
         return self.connection
 
-    def message(self):
-        encoding = self.encoding or settings.DEFAULT_CHARSET
-        msg = SafeMIMEText(self.body, self.content_subtype, encoding)
-        msg = self._create_message(msg)
-        msg["Subject"] = self.subject
-        msg["From"] = self.extra_headers.get("From", self.from_email)
+    def message(self, *, policy=email.policy.default):
+        msg = email.message.EmailMessage(policy=policy)
+        self._add_bodies(msg)
+        self._add_attachments(msg)
+
+        msg["Subject"] = str(self.subject)
+        msg["From"] = str(self.extra_headers.get("From", self.from_email))
         self._set_list_header_if_not_empty(msg, "To", self.to)
         self._set_list_header_if_not_empty(msg, "Cc", self.cc)
         self._set_list_header_if_not_empty(msg, "Reply-To", self.reply_to)
@@ -277,18 +114,19 @@ class EmailMessage:
         # accommodate that when doing comparisons.
         header_names = [key.lower() for key in self.extra_headers]
         if "date" not in header_names:
-            # formatdate() uses stdlib methods to format the date, which use
-            # the stdlib/OS concept of a timezone, however, Django sets the
-            # TZ environment variable based on the TIME_ZONE setting which
-            # will get picked up by formatdate().
-            msg["Date"] = formatdate(localtime=settings.EMAIL_USE_LOCALTIME)
+            if settings.EMAIL_USE_LOCALTIME:
+                tz = get_current_timezone()
+            else:
+                tz = timezone.utc
+            msg["Date"] = datetime.now(tz)
         if "message-id" not in header_names:
             # Use cached DNS_NAME for performance
             msg["Message-ID"] = make_msgid(domain=DNS_NAME)
         for name, value in self.extra_headers.items():
             # Avoid headers handled above.
             if name.lower() not in {"from", "to", "cc", "reply-to"}:
-                msg[name] = value
+                msg[name] = force_str(value, strings_only=True)
+        self._idna_encode_address_header_domains(msg)
         return msg
 
     def recipients(self):
@@ -318,7 +156,19 @@ class EmailMessage:
         specified as content, decode it as UTF-8. If that fails, set the
         mimetype to DEFAULT_ATTACHMENT_MIME_TYPE and don't decode the content.
         """
-        if isinstance(filename, MIMEBase):
+        if isinstance(filename, email.message.MIMEPart):
+            if content is not None or mimetype is not None:
+                raise ValueError(
+                    "content and mimetype must not be given when a MIMEPart "
+                    "instance is provided."
+                )
+            self.attachments.append(filename)
+        elif isinstance(filename, MIMEBase):
+            warnings.warn(
+                "MIMEBase attachments are deprecated."
+                " Use an email.message.MIMEPart instead.",
+                RemovedInDjango61Warning,
+            )
             if content is not None or mimetype is not None:
                 raise ValueError(
                     "content and mimetype must not be given when a MIMEBase "
@@ -362,68 +212,69 @@ class EmailMessage:
             content = file.read()
             self.attach(path.name, content, mimetype)
 
-    def _create_message(self, msg):
-        return self._create_attachments(msg)
-
-    def _create_attachments(self, msg):
-        if self.attachments:
+    def _add_bodies(self, msg):
+        if self.body or not self.attachments:
             encoding = self.encoding or settings.DEFAULT_CHARSET
-            body_msg = msg
-            msg = SafeMIMEMultipart(_subtype=self.mixed_subtype, encoding=encoding)
-            if self.body or body_msg.is_multipart():
-                msg.attach(body_msg)
+            body = force_str(
+                self.body or "", encoding=encoding, errors="surrogateescape"
+            )
+            msg.set_content(body, subtype=self.content_subtype, charset=encoding)
+
+    def _add_attachments(self, msg):
+        if self.attachments:
+            if hasattr(self, "mixed_subtype"):
+                # RemovedInDjango61Warning
+                raise AttributeError(
+                    "EmailMessage no longer supports the"
+                    " undocumented `mixed_subtype` attribute"
+                )
+            msg.make_mixed()
             for attachment in self.attachments:
-                if isinstance(attachment, MIMEBase):
+                if isinstance(attachment, email.message.MIMEPart):
+                    msg.attach(attachment)
+                elif isinstance(attachment, MIMEBase):
+                    # RemovedInDjango61Warning
                     msg.attach(attachment)
                 else:
-                    msg.attach(self._create_attachment(*attachment))
-        return msg
+                    self._add_attachment(msg, *attachment)
 
-    def _create_mime_attachment(self, content, mimetype):
-        """
-        Convert the content, mimetype pair into a MIME attachment object.
-
-        If the mimetype is message/rfc822, content may be an
-        email.Message or EmailMessage object, as well as a str.
-        """
-        basetype, subtype = mimetype.split("/", 1)
-        if basetype == "text":
-            encoding = self.encoding or settings.DEFAULT_CHARSET
-            attachment = SafeMIMEText(content, subtype, encoding)
-        elif basetype == "message" and subtype == "rfc822":
-            # Bug #18967: Per RFC 2046 Section 5.2.1, message/rfc822
-            # attachments must not be base64 encoded.
-            if isinstance(content, EmailMessage):
-                # convert content into an email.Message first
-                content = content.message()
-            elif not isinstance(content, Message):
-                # For compatibility with existing code, parse the message
-                # into an email.Message object if it is not one already.
-                content = message_from_string(force_str(content))
-
-            attachment = SafeMIMEMessage(content, subtype)
-        else:
-            # Encode non-text attachments with base64.
-            attachment = MIMEBase(basetype, subtype)
-            attachment.set_payload(content)
-            Encoders.encode_base64(attachment)
-        return attachment
-
-    def _create_attachment(self, filename, content, mimetype=None):
-        """
-        Convert the filename, content, mimetype triple into a MIME attachment
-        object.
-        """
-        attachment = self._create_mime_attachment(content, mimetype)
-        if filename:
-            try:
-                filename.encode("ascii")
-            except UnicodeEncodeError:
-                filename = ("utf-8", "", filename)
-            attachment.add_header(
-                "Content-Disposition", "attachment", filename=filename
+    def _add_attachment(self, msg, filename, content, mimetype):
+        encoding = self.encoding or settings.DEFAULT_CHARSET
+        if mimetype is None:
+            mimetype = DEFAULT_ATTACHMENT_MIME_TYPE
+        maintype, subtype = mimetype.split("/", 1)
+        # See email.contentmanager.set_content() docs for the cases here.
+        if maintype == "text":
+            # For text/*, content must be str, and maintype cannot be provided.
+            if isinstance(content, bytes):
+                content = content.decode()
+            msg.add_attachment(
+                content, subtype=subtype, filename=filename, charset=encoding
             )
-        return attachment
+        elif maintype == "message":
+            # For message/*, content must be email.message.EmailMessage (or
+            # legacy email.message.Message), and maintype cannot be provided.
+            if isinstance(content, EmailMessage):
+                # Django EmailMessage.
+                content = content.message(policy=msg.policy)
+            elif not isinstance(
+                content, (email.message.EmailMessage, email.message.Message)
+            ):
+                content = email.message_from_bytes(
+                    force_bytes(content), policy=msg.policy
+                )
+            msg.add_attachment(content, subtype=subtype, filename=filename)
+        else:
+            # For all other types, content must be bytes-like, and both
+            # maintype and subtype must be provided.
+            if not isinstance(content, (bytes, bytearray, memoryview)):
+                content = force_bytes(content)
+            msg.add_attachment(
+                content,
+                maintype=maintype,
+                subtype=subtype,
+                filename=filename,
+            )
 
     def _set_list_header_if_not_empty(self, msg, header, values):
         """
@@ -436,6 +287,34 @@ class EmailMessage:
             if values:
                 msg[header] = ", ".join(str(v) for v in values)
 
+    def _idna_encode_address_header_domains(self, msg):
+        """
+        If msg.policy does not permit utf8 in headers, IDNA encode all non-ASCII
+        domains in its address headers.
+        """
+        # Avoids a problem where Python's email incorrectly converts non-ASCII domains
+        # to RFC 2047 encoded-words: https://github.com/python/cpython/issues/83938.
+        # This applies to the domain only, not to the localpart (username). There is no
+        # RFC that permits any 7-bit encoding for non-ASCII characters before the '@'.
+        if not getattr(msg.policy, "utf8", False):
+            # Not using SMTPUTF8, so apply IDNA encoding in all address headers.
+            # (IDNA encoding does not alter domains that are already ASCII.)
+            for field, value in msg.items():
+                if isinstance(value, AddressHeader) and any(
+                    not addr.domain.isascii() for addr in value.addresses
+                ):
+                    msg.replace_header(
+                        field,
+                        [
+                            Address(
+                                display_name=addr.display_name,
+                                username=addr.username,
+                                domain=punycode(addr.domain),
+                            )
+                            for addr in value.addresses
+                        ],
+                    )
+
 
 class EmailMultiAlternatives(EmailMessage):
     """
@@ -443,8 +322,6 @@ class EmailMultiAlternatives(EmailMessage):
     messages. For example, including text and HTML versions of the text is
     made easier.
     """
-
-    alternative_subtype = "alternative"
 
     def __init__(
         self,
@@ -486,24 +363,28 @@ class EmailMultiAlternatives(EmailMessage):
             raise ValueError("Both content and mimetype must be provided.")
         self.alternatives.append(EmailAlternative(content, mimetype))
 
-    def _create_message(self, msg):
-        return self._create_attachments(self._create_alternatives(msg))
-
-    def _create_alternatives(self, msg):
-        encoding = self.encoding or settings.DEFAULT_CHARSET
+    def _add_bodies(self, msg):
+        if self.body or not self.alternatives:
+            super()._add_bodies(msg)
         if self.alternatives:
-            body_msg = msg
-            msg = SafeMIMEMultipart(
-                _subtype=self.alternative_subtype, encoding=encoding
-            )
-            if self.body:
-                msg.attach(body_msg)
-            for alternative in self.alternatives:
-                msg.attach(
-                    self._create_mime_attachment(
-                        alternative.content, alternative.mimetype
-                    )
+            if hasattr(self, "alternative_subtype"):
+                # RemovedInDjango61Warning
+                raise AttributeError(
+                    "EmailMultiAlternatives no longer supports the"
+                    " undocumented `alternative_subtype` attribute"
                 )
+            msg.make_alternative()
+            encoding = self.encoding or settings.DEFAULT_CHARSET
+            for alternative in self.alternatives:
+                maintype, subtype = alternative.mimetype.split("/", 1)
+                content = alternative.content
+                if maintype == "text":
+                    if isinstance(content, bytes):
+                        content = content.decode()
+                    msg.add_alternative(content, subtype=subtype, charset=encoding)
+                else:
+                    content = force_bytes(content, encoding=encoding, strings_only=True)
+                    msg.add_alternative(content, maintype=maintype, subtype=subtype)
         return msg
 
     def body_contains(self, text):

--- a/docs/releases/5.2.txt
+++ b/docs/releases/5.2.txt
@@ -220,6 +220,13 @@ Email
   returns a boolean indicating whether a provided text is contained in the
   email ``body`` and in all attached MIME type ``text/*`` alternatives.
 
+* ``EmailMessage.message()`` now uses Python's "modern email" API and returns
+  an instance of :class:`email.message.EmailMessage`. It accepts a new
+  ``policy`` argument.
+
+* ``EmailMessage.attach()`` now accepts a :class:`~email.message.MIMEPart`
+  object from Python's modern email API.
+
 Error Reporting
 ~~~~~~~~~~~~~~~
 
@@ -416,6 +423,15 @@ MySQL connections now default to using the ``utf8mb4`` character set, instead
 of ``utf8``, which is an alias for the deprecated character set ``utf8mb3``.
 ``utf8mb3`` can be specified in the ``OPTIONS`` part of the ``DATABASES``
 setting, if needed for legacy databases.
+Email
+-----
+
+* The undocumented ``mixed_subtype`` and ``alternative_subtype`` properties
+  of :class:`~django.core.mail.EmailMessage` and
+  :class:`~django.core.mail.EmailMultiAlternatives` are no longer supported.
+
+* The undocumented ``encoding`` property of :class:`~django.core.mail.EmailMessage`
+  no longer supports Python legacy :py:class:`email.charset.Charset` objects.
 
 Miscellaneous
 -------------
@@ -456,6 +472,24 @@ Miscellaneous
 
 Features deprecated in 5.2
 ==========================
+
+Email
+-----
+
+* Passing Python's legacy email :class:`~email.mime.base.MIMEBase` object to
+  ``EmailMessage.attach()`` (or including one in the message's ``attachments``
+  list) is deprecated. For complex attachments requiring additional headers or
+  parameters, switch to the modern email API's :class:`~email.message.MIMEPart`.
+
+* ``BadHeaderError`` is deprecated. Python's modern email raises a
+  :exc:`!ValueError` for email headers containing prohibited characters.
+
+* ``django.core.mail.SafeMIMEText`` and ``SafeMIMEMultipart`` are deprecated.
+  (In earlier releases, they had been documented as the return types of
+  ``EmailMessage.message()``.)
+
+* The undocumented email APIs ``django.core.mail.forbid_multi_line_headers()``
+  and ``django.core.mail.message.sanitize_address()`` are deprecated.
 
 Miscellaneous
 -------------

--- a/docs/topics/email.txt
+++ b/docs/topics/email.txt
@@ -224,7 +224,7 @@ The Django email functions outlined above all protect against header injection
 by forbidding newlines in header values. If any ``subject``, ``from_email`` or
 ``recipient_list`` contains a newline (in either Unix, Windows or Mac style),
 the email function (e.g. :meth:`~django.core.mail.send_mail()`) will raise
-``django.core.mail.BadHeaderError`` (a subclass of ``ValueError``) and, hence,
+:exc:`ValueError` and, hence,
 will not send the email. It's your responsibility to validate all data before
 passing it to the email functions.
 
@@ -235,7 +235,7 @@ Here's an example view that takes a ``subject``, ``message`` and ``from_email``
 from the request's POST data, sends that to admin@example.com and redirects to
 "/contact/thanks/" when it's done::
 
-    from django.core.mail import BadHeaderError, send_mail
+    from django.core.mail import send_mail
     from django.http import HttpResponse, HttpResponseRedirect
 
 
@@ -246,13 +246,20 @@ from the request's POST data, sends that to admin@example.com and redirects to
         if subject and message and from_email:
             try:
                 send_mail(subject, message, from_email, ["admin@example.com"])
-            except BadHeaderError:
+            except ValueError:
                 return HttpResponse("Invalid header found.")
             return HttpResponseRedirect("/contact/thanks/")
         else:
             # In reality we'd use a form class
             # to get proper validation errors.
             return HttpResponse("Make sure all fields are entered and valid.")
+
+
+.. versionchanged:: 5.2
+
+    The ``django.core.mail.BadHeaderError`` raised for some invalid headers
+    was replaced with a regular :exc:`!ValueError`.
+
 
 .. _Header injection: http://www.nyphp.org/phundamentals/8_Preventing-Email-Header-Injection.html
 
@@ -317,15 +324,16 @@ All parameters are optional and can be set at any time prior to calling the
   connection is created when ``send()`` is called. This parameter is ignored
   when using :ref:`send_messages() <topics-sending-multiple-emails>`.
 
-* ``attachments``: A list of attachments to put on the message. These can
-  be instances of :class:`~email.mime.base.MIMEBase` or
+* ``attachments``: A list of attachments to put on the message. Each can
+  be an instance of :class:`~email.message.MIMEPart` or
   :class:`~django.core.mail.EmailAttachment`, or a tuple with attributes
   ``(filename, content, mimetype)``.
 
   .. versionchanged:: 5.2
 
-    Support for :class:`~django.core.mail.EmailAttachment` items of
-    ``attachments`` were added.
+      Added support for :class:`~django.core.mail.EmailAttachment`
+      and :class:`~email.message.MIMEPart` items. Deprecated support for
+      :class:`~email.mime.base.MIMEBase` objects in ``attachments``.
 
 * ``headers``: A dictionary of extra headers to put on the message. The
   keys are the header name, values are the header values. It's up to the
@@ -362,12 +370,18 @@ The class has the following methods:
   recipients will not raise an exception. It will return ``1`` if the message
   was sent successfully, otherwise ``0``.
 
-* ``message()`` constructs a ``django.core.mail.SafeMIMEText`` object (a
-  subclass of Python's :class:`~email.mime.text.MIMEText` class) or a
-  ``django.core.mail.SafeMIMEMultipart`` object holding the message to be
-  sent. If you ever need to extend the
-  :class:`~django.core.mail.EmailMessage` class, you'll probably want to
-  override this method to put the content you want into the MIME object.
+* ``message(policy=email.policy.default)`` constructs and returns a Python
+  :class:`email.message.EmailMessage` object using the specified policy,
+  representing the message to be sent.
+
+  If you ever need to extend Django's :class:`~django.core.mail.EmailMessage`
+  class, you'll probably want to override this method to put the content you
+  want into Python EmailMessage object.
+
+  .. versionchanged:: 5.2
+
+      Added the ``policy`` argument and updated the method to return
+      a modern Python :py:class:`~email.message.EmailMessage`.
 
 * ``recipients()`` returns a list of all the recipients of the message,
   whether they're recorded in the ``to``, ``cc`` or ``bcc`` attributes. This
@@ -376,15 +390,11 @@ The class has the following methods:
   is sent. If you add another way to specify recipients in your class, they
   need to be returned from this method as well.
 
-* ``attach()`` creates a new file attachment and adds it to the message.
+* ``attach()`` creates a new attachment and adds it to the message.
   There are two ways to call ``attach()``:
 
-  * You can pass it a single argument that is a
-    :class:`~email.mime.base.MIMEBase` instance. This will be inserted directly
-    into the resulting message.
-
-  * Alternatively, you can pass ``attach()`` three arguments:
-    ``filename``, ``content`` and ``mimetype``. ``filename`` is the name
+  * You can pass it three arguments: ``filename``, ``content``
+    and ``mimetype``. ``filename`` is the name
     of the file attachment as it will appear in the email, ``content`` is
     the data that will be contained inside the attachment and
     ``mimetype`` is the optional MIME type for the attachment. If you
@@ -395,21 +405,41 @@ The class has the following methods:
 
        message.attach("design.png", img_data, "image/png")
 
-    If you specify a ``mimetype`` of :mimetype:`message/rfc822`, it will also
-    accept :class:`django.core.mail.EmailMessage` and
-    :py:class:`email.message.Message`.
+    If you specify a ``mimetype`` of :mimetype:`message/rfc822`, ``content``
+    can be a :class:`django.core.mail.EmailMessage` or Python's
+    :class:`email.message.EmailMessage` or :class:`email.message.Message`.
+    (``filename`` can be ``None`` in this case.)
 
     For a ``mimetype`` starting with :mimetype:`text/`, content is expected to
     be a string. Binary data will be decoded using UTF-8, and if that fails,
     the MIME type will be changed to :mimetype:`application/octet-stream` and
     the data will be attached unchanged.
 
-    In addition, :mimetype:`message/rfc822` attachments will no longer be
-    base64-encoded in violation of :rfc:`2046#section-5.2.1`, which can cause
-    issues with displaying the attachments in `Evolution`__ and `Thunderbird`__.
+  * Or for attachments requiring additional headers or parameters, you can pass
+    ``attach()`` a single Python :class:`~email.message.MIMEPart` object.
+    This will be attached directly to the resulting message. For example,
+    to attach an inline image with a :mailheader:`Content-ID`::
 
-    __ https://bugzilla.gnome.org/show_bug.cgi?id=651197
-    __ https://bugzilla.mozilla.org/show_bug.cgi?id=333880
+        cid = email.utils.make_msgid()
+        inline_image = email.message.MIMEPart()
+        inline_image.set_content(
+            image_data_bytes,
+            maintype="image",
+            subtype="png",
+            disposition="inline",
+            cid=f"<{cid}>",
+        )
+        message.attach(inline_image)
+        message.attach_alternative(f'… <img src="cid:${cid}"> …', "text/html")
+
+    Python's :meth:`email.contentmanager.set_content` documentation describes
+    the supported arguments for ``MIMEPart.set_content()``.
+
+    .. versionchanged:: 5.2
+
+        Added support for Python's modern email :class:`~email.message.MIMEPart`
+        attachments and deprecated using legacy
+        :class:`email.mime.base.MIMEBase` objects.
 
 * ``attach_file()`` creates a new attachment using a file from your
   filesystem. Call it with the path of the file to attach and, optionally,

--- a/tests/auth_tests/test_forms.py
+++ b/tests/auth_tests/test_forms.py
@@ -1347,13 +1347,13 @@ class PasswordResetFormTest(TestDataMixin, TestCase):
         self.assertTrue(
             re.match(
                 r"^http://example.com/reset/[\w/-]+",
-                message.get_payload(0).get_payload(),
+                message.get_payload(0).get_content(),
             )
         )
         self.assertTrue(
             re.match(
                 r'^<html><a href="http://example.com/reset/[\w/-]+/">Link</a></html>$',
-                message.get_payload(1).get_payload(),
+                message.get_payload(1).get_content(),
             )
         )
 

--- a/tests/mail/test_deprecated.py
+++ b/tests/mail/test_deprecated.py
@@ -1,0 +1,364 @@
+# RemovedInDjango61Warning: this entire file
+from email.mime.image import MIMEImage
+from email.mime.text import MIMEText
+from unittest import mock
+
+from django.core.mail import (
+    EmailAlternative,
+    EmailAttachment,
+    EmailMessage,
+    EmailMultiAlternatives,
+)
+from django.test import SimpleTestCase, ignore_warnings
+from django.utils.deprecation import RemovedInDjango61Warning
+
+from .tests import MailTestsMixin
+
+
+class DeprecationWarningTests(MailTestsMixin, SimpleTestCase):
+    def test_attach_mime_image(self):
+        """
+        EmailMessage.attach() docs: "You can pass it
+        a single argument that is a MIMEBase instance."
+        """
+        msg = (
+            "MIMEBase attachments are deprecated."
+            " Use an email.message.MIMEPart instead."
+        )
+        # This also verifies complex attachments with extra header fields.
+        email = EmailMessage()
+        image = MIMEImage(b"GIF89a...", "gif")
+        image["Content-Disposition"] = "inline"
+        image["Content-ID"] = "<content-id@example.org>"
+        with self.assertWarnsMessage(RemovedInDjango61Warning, msg):
+            email.attach(image)
+
+        attachments = self.get_raw_attachments(email)
+        self.assertEqual(len(attachments), 1)
+        image_att = attachments[0]
+        self.assertEqual(image_att.get_content_type(), "image/gif")
+        self.assertEqual(image_att.get_content_disposition(), "inline")
+        self.assertEqual(image_att["Content-ID"], "<content-id@example.org>")
+        self.assertEqual(image_att.get_content(), b"GIF89a...")
+        self.assertIsNone(image_att.get_filename())
+
+    def test_attach_mime_image_in_constructor(self):
+        msg = (
+            "MIMEBase attachments are deprecated."
+            " Use an email.message.MIMEPart instead."
+        )
+        image = MIMEImage(b"\x89PNG...", "png")
+        image["Content-Disposition"] = "attachment; filename=test.png"
+        with self.assertWarnsMessage(RemovedInDjango61Warning, msg):
+            email = EmailMessage(attachments=[image])
+
+        attachments = self.get_raw_attachments(email)
+        self.assertEqual(len(attachments), 1)
+        image_att = attachments[0]
+        self.assertEqual(image_att.get_content_type(), "image/png")
+        self.assertEqual(image_att.get_content(), b"\x89PNG...")
+        self.assertEqual(image_att.get_filename(), "test.png")
+
+    def test_deprecated_on_import(self):
+        """
+        These items are not typically called from user code,
+        so generate deprecation warnings immediately at the time
+        they are imported from django.core.mail.
+        """
+        cases = [
+            # name, msg
+            (
+                "BadHeaderError",
+                "BadHeaderError is deprecated. Replace with ValueError.",
+            ),
+            (
+                "SafeMIMEText",
+                "SafeMIMEText is deprecated. The return value of"
+                " EmailMessage.message() is an email.message.EmailMessage.",
+            ),
+            (
+                "SafeMIMEMultipart",
+                "SafeMIMEMultipart is deprecated. The return value of"
+                " EmailMessage.message() is an email.message.EmailMessage.",
+            ),
+            (
+                "forbid_multi_line_headers",
+                "The internal API forbid_multi_line_headers() is deprecated.",
+            ),
+        ]
+        for name, msg in cases:
+            with self.subTest(name=name):
+                with self.assertWarnsMessage(RemovedInDjango61Warning, msg):
+                    __import__("django.core.mail", fromlist=[name])
+
+    def test_sanitize_address_deprecated(self):
+        from django.core.mail.message import sanitize_address
+
+        msg = "The internal API sanitize_address() is deprecated."
+        with self.assertWarnsMessage(RemovedInDjango61Warning, msg):
+            sanitize_address("to@example.com", "ascii")
+
+    def test_forbid_multi_line_headers_deprecated(self):
+        # Import from _deprecated to avoid warning on import.
+        # This function also warns (with a more detailed message) on use.
+        from django.core.mail._deprecated import forbid_multi_line_headers
+
+        msg = "The internal API forbid_multi_line_headers() is deprecated."
+        with self.assertWarnsMessage(RemovedInDjango61Warning, msg):
+            forbid_multi_line_headers("To", "to@example.com", "ascii")
+
+
+class UndocumentedFeatureErrorTests(SimpleTestCase):
+    """
+    These undocumented features were removed without going through deprecation.
+    In case they were being used, they now raise errors.
+    """
+
+    def test_undocumented_mixed_subtype(self):
+        """
+        Trying to use the previously undocumented, now unsupported
+        EmailMessage.mixed_subtype causes an error.
+        """
+        msg = (
+            "EmailMessage no longer supports"
+            " the undocumented `mixed_subtype` attribute"
+        )
+        email = EmailMessage(
+            attachments=[EmailAttachment(None, b"GIF89a...", "image/gif")]
+        )
+        email.mixed_subtype = "related"
+        with self.assertRaisesMessage(AttributeError, msg):
+            email.message()
+
+    def test_undocumented_alternative_subtype(self):
+        """
+        Trying to use the previously undocumented, now unsupported
+        EmailMultiAlternatives.alternative_subtype causes an error.
+        """
+        msg = (
+            "EmailMultiAlternatives no longer supports"
+            " the undocumented `alternative_subtype` attribute"
+        )
+        email = EmailMultiAlternatives(
+            alternatives=[EmailAlternative("", "text/plain")]
+        )
+        email.alternative_subtype = "multilingual"
+        with self.assertRaisesMessage(AttributeError, msg):
+            email.message()
+
+
+@ignore_warnings(category=RemovedInDjango61Warning)
+class DeprecatedCompatibilityTests(SimpleTestCase):
+    def test_bad_header_error(self):
+        """
+        Existing code that catches deprecated BadHeaderError should be
+        compatible with modern email (which raises ValueError instead).
+        """
+        from django.core.mail import BadHeaderError
+
+        with self.assertRaises(BadHeaderError):
+            EmailMessage(subject="Bad\r\nHeader").message()
+
+    def test_attachments_mimebase_in_constructor(self):
+        txt = MIMEText("content1")
+        msg = EmailMessage(attachments=[txt])
+        payload = msg.message().get_payload()
+        self.assertEqual(payload[0], txt)
+
+
+@ignore_warnings(category=RemovedInDjango61Warning)
+class DeprecatedFeatureTests(SimpleTestCase):
+    """
+    Original test cases for the deprecated email features.
+    """
+
+    @mock.patch("django.core.mail._deprecated.MIMEText.set_payload")
+    def test_nonascii_as_string_with_ascii_charset(self, mock_set_payload):
+        """Line length check should encode the payload supporting `surrogateescape`.
+
+        Following https://github.com/python/cpython/issues/76511, newer
+        versions of Python (3.11.9, 3.12.3 and 3.13) ensure that a message's
+        payload is encoded with the provided charset and `surrogateescape` is
+        used as the error handling strategy.
+
+        This test is heavily based on the test from the fix for the bug above.
+        Line length checks in SafeMIMEText's set_payload should also use the
+        same error handling strategy to avoid errors such as:
+
+        UnicodeEncodeError: 'utf-8' codec can't encode <...>: surrogates not allowed
+        """
+        from django.core.mail import SafeMIMEText
+
+        def simplified_set_payload(instance, payload, charset):
+            instance._payload = payload
+
+        mock_set_payload.side_effect = simplified_set_payload
+
+        text = (
+            "Text heavily based in Python's text for non-ascii messages: Föö bär"
+        ).encode("iso-8859-1")
+        body = text.decode("ascii", errors="surrogateescape")
+        message = SafeMIMEText(body, "plain", "ascii")
+        mock_set_payload.assert_called_once()
+        self.assertEqual(message.get_payload(decode=True), text)
+
+    def test_sanitize_address(self):
+        """Email addresses are properly sanitized."""
+        from django.core.mail.message import sanitize_address
+
+        for email_address, encoding, expected_result in (
+            # ASCII addresses.
+            ("to@example.com", "ascii", "to@example.com"),
+            ("to@example.com", "utf-8", "to@example.com"),
+            (("A name", "to@example.com"), "ascii", "A name <to@example.com>"),
+            (
+                ("A name", "to@example.com"),
+                "utf-8",
+                "A name <to@example.com>",
+            ),
+            ("localpartonly", "ascii", "localpartonly"),
+            # ASCII addresses with display names.
+            ("A name <to@example.com>", "ascii", "A name <to@example.com>"),
+            ("A name <to@example.com>", "utf-8", "A name <to@example.com>"),
+            ('"A name" <to@example.com>', "ascii", "A name <to@example.com>"),
+            ('"A name" <to@example.com>', "utf-8", "A name <to@example.com>"),
+            # Unicode addresses: IDNA encoded domain supported per RFC-5890.
+            # But an 'encoded-word' localpart is prohibited by RFC-2047, and not
+            # supported by any known mail service. This incorrect behavior
+            # is preserved in sanitize_address() for compatibility.
+            ("tó@example.com", "utf-8", "=?utf-8?b?dMOz?=@example.com"),
+            ("to@éxample.com", "utf-8", "to@xn--xample-9ua.com"),
+            (
+                ("Tó Example", "tó@example.com"),
+                "utf-8",
+                # (Not RFC-2047 compliant.)
+                "=?utf-8?q?T=C3=B3_Example?= <=?utf-8?b?dMOz?=@example.com>",
+            ),
+            # Unicode addresses with display names.
+            (
+                "Tó Example <tó@example.com>",
+                "utf-8",
+                # (Not RFC-2047 compliant.)
+                "=?utf-8?q?T=C3=B3_Example?= <=?utf-8?b?dMOz?=@example.com>",
+            ),
+            (
+                "To Example <to@éxample.com>",
+                "ascii",
+                "To Example <to@xn--xample-9ua.com>",
+            ),
+            (
+                "To Example <to@éxample.com>",
+                "utf-8",
+                "To Example <to@xn--xample-9ua.com>",
+            ),
+            # Addresses with two @ signs.
+            ('"to@other.com"@example.com', "utf-8", r'"to@other.com"@example.com'),
+            (
+                '"to@other.com" <to@example.com>',
+                "utf-8",
+                '"to@other.com" <to@example.com>',
+            ),
+            (
+                ("To Example", "to@other.com@example.com"),
+                "utf-8",
+                'To Example <"to@other.com"@example.com>',
+            ),
+            # Addresses with long unicode display names.
+            (
+                "Tó Example very long" * 4 + " <to@example.com>",
+                "utf-8",
+                "=?utf-8?q?T=C3=B3_Example_very_longT=C3=B3_Example_very_longT"
+                "=C3=B3_Example_?=\n"
+                " =?utf-8?q?very_longT=C3=B3_Example_very_long?= "
+                "<to@example.com>",
+            ),
+            (
+                ("Tó Example very long" * 4, "to@example.com"),
+                "utf-8",
+                "=?utf-8?q?T=C3=B3_Example_very_longT=C3=B3_Example_very_longT"
+                "=C3=B3_Example_?=\n"
+                " =?utf-8?q?very_longT=C3=B3_Example_very_long?= "
+                "<to@example.com>",
+            ),
+            # Address with long display name and unicode domain.
+            (
+                ("To Example very long" * 4, "to@exampl€.com"),
+                "utf-8",
+                "To Example very longTo Example very longTo Example very longT"
+                "o Example very\n"
+                " long <to@xn--exampl-nc1c.com>",
+            ),
+        ):
+            with self.subTest(email_address=email_address, encoding=encoding):
+                self.assertEqual(
+                    sanitize_address(email_address, encoding), expected_result
+                )
+
+    def test_sanitize_address_invalid(self):
+        from django.core.mail.message import sanitize_address
+
+        for email_address in (
+            # Invalid address with two @ signs.
+            "to@other.com@example.com",
+            # Invalid address without the quotes.
+            "to@other.com <to@example.com>",
+            # Other invalid addresses.
+            "@",
+            "to@",
+            "@example.com",
+            ("", ""),
+        ):
+            with self.subTest(email_address=email_address):
+                with self.assertRaisesMessage(ValueError, "Invalid address"):
+                    sanitize_address(email_address, encoding="utf-8")
+
+    def test_sanitize_address_header_injection(self):
+        from django.core.mail.message import sanitize_address
+
+        msg = "Invalid address; address parts cannot contain newlines."
+        tests = [
+            "Name\nInjection <to@example.com>",
+            ("Name\nInjection", "to@xample.com"),
+            "Name <to\ninjection@example.com>",
+            ("Name", "to\ninjection@example.com"),
+        ]
+        for email_address in tests:
+            with self.subTest(email_address=email_address):
+                with self.assertRaisesMessage(ValueError, msg):
+                    sanitize_address(email_address, encoding="utf-8")
+
+
+class PythonGlobalState(SimpleTestCase):
+    """
+    Tests for #12422 -- Django smarts (#2472/#11212) with charset of utf-8 text
+    parts shouldn't pollute global email Python package charset registry when
+    django.mail.message is imported.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        # Make sure code that creates custom email charsets has been run.
+        from django.core.mail._deprecated import (  # NOQA: F401
+            utf8_charset,
+            utf8_charset_qp,
+        )
+
+    def test_utf8(self):
+        txt = MIMEText("UTF-8 encoded body", "plain", "utf-8")
+        self.assertIn("Content-Transfer-Encoding: base64", txt.as_string())
+
+    def test_7bit(self):
+        txt = MIMEText("Body with only ASCII characters.", "plain", "utf-8")
+        self.assertIn("Content-Transfer-Encoding: base64", txt.as_string())
+
+    def test_8bit_latin(self):
+        txt = MIMEText("Body with latin characters: àáä.", "plain", "utf-8")
+        self.assertIn("Content-Transfer-Encoding: base64", txt.as_string())
+
+    def test_8bit_non_latin(self):
+        txt = MIMEText(
+            "Body with non latin characters: А Б В Г Д Е Ж Ѕ З И І К Л М Н О П.",
+            "plain",
+            "utf-8",
+        )
+        self.assertIn("Content-Transfer-Encoding: base64", txt.as_string())

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -7,11 +7,15 @@ import tempfile
 from email import charset, message_from_binary_file
 from email import message_from_bytes as _message_from_bytes
 from email import policy
+from email.message import EmailMessage as PyEmailMessage
+from email.message import Message as PyMessage
+from email.mime.image import MIMEImage
 from email.mime.text import MIMEText
 from io import StringIO
 from pathlib import Path
 from smtplib import SMTP, SMTPException
 from ssl import SSLError
+from textwrap import dedent
 from unittest import mock, skipUnless
 
 from django.core import mail
@@ -138,6 +142,26 @@ class MailTestsMixin:
             )
             for attachment in self.get_raw_attachments(django_message)
         ]
+
+    def get_message_structure(self, message, level=0):
+        """
+        Return a multiline indented string representation
+        of the message's MIME content-type structure, e.g.:
+
+            multipart/mixed
+                multipart/alternative
+                    text/plain
+                    text/html
+                image/jpg
+                text/calendar
+        """
+        # Adapted from email.iterators._structure().
+        indent = " " * (level * 4)
+        structure = [f"{indent}{message.get_content_type()}\n"]
+        if message.is_multipart():
+            for subpart in message.get_payload():
+                structure.append(self.get_message_structure(subpart, level + 1))
+        return "".join(structure)
 
 
 class MailTests(MailTestsMixin, SimpleTestCase):
@@ -298,6 +322,20 @@ class MailTests(MailTestsMixin, SimpleTestCase):
             headers={"Cc": "foo@example.com"},
         ).message()
         self.assertEqual(message.get_all("Cc"), ["foo@example.com"])
+
+    def test_bcc_not_in_headers(self):
+        """
+        A bcc address should be in the recipients,
+        but not in the (visible) message headers.
+        """
+        email = EmailMessage(
+            to=["to@example.com"],
+            bcc=["bcc@example.com"],
+        )
+        message = email.message()
+        self.assertNotIn("Bcc", message)
+        self.assertNotIn("bcc@example.com", message.as_string())
+        self.assertEqual(email.recipients(), ["to@example.com", "bcc@example.com"])
 
     def test_reply_to(self):
         email = EmailMessage(
@@ -875,6 +913,97 @@ class MailTests(MailTestsMixin, SimpleTestCase):
         self.assertEqual(content, b"\xff")
         self.assertEqual(mimetype, "application/octet-stream")
 
+    def test_attach_mime_image(self):
+        """
+        EmailMessage.attach() docs: "You can pass it
+        a single argument that is a MIMEBase instance."
+        """
+        # This also verifies complex attachments with extra header fields.
+        email = EmailMessage()
+        image = MIMEImage(b"GIF89a...", "gif")
+        image["Content-Disposition"] = "inline"
+        image["Content-ID"] = "<content-id@example.org>"
+        email.attach(image)
+
+        attachments = self.get_raw_attachments(email)
+        self.assertEqual(len(attachments), 1)
+        image_att = attachments[0]
+        self.assertEqual(image_att.get_content_type(), "image/gif")
+        self.assertEqual(image_att.get_content_disposition(), "inline")
+        self.assertEqual(image_att["Content-ID"], "<content-id@example.org>")
+        self.assertEqual(image_att.get_content(), b"GIF89a...")
+        self.assertIsNone(image_att.get_filename())
+
+    def test_attach_mime_image_in_constructor(self):
+        image = MIMEImage(b"\x89PNG...", "png")
+        image["Content-Disposition"] = "attachment; filename=test.png"
+        email = EmailMessage(attachments=[image])
+
+        attachments = self.get_raw_attachments(email)
+        self.assertEqual(len(attachments), 1)
+        image_att = attachments[0]
+        self.assertEqual(image_att.get_content_type(), "image/png")
+        self.assertEqual(image_att.get_content(), b"\x89PNG...")
+        self.assertEqual(image_att.get_content_disposition(), "attachment")
+        self.assertEqual(image_att.get_filename(), "test.png")
+
+    def test_attach_rfc822_message(self):
+        """
+        EmailMessage.attach() docs: "If you specify a mimetype of message/rfc822,
+        it will also accept django.core.mail.EmailMessage and email.message.Message."
+        """
+        # django.core.mail.EmailMessage
+        django_email = EmailMessage("child subject", "child body")
+        # email.message.Message
+        py_message = PyMessage()
+        py_message["Subject"] = "child subject"
+        py_message.set_payload("child body")
+        # email.message.EmailMessage
+        py_email_message = PyEmailMessage()
+        py_email_message["Subject"] = "child subject"
+        py_email_message.set_content("child body")
+
+        cases = [
+            django_email,
+            py_message,
+            py_email_message,
+            # Should also allow message serialized as str or bytes.
+            py_message.as_string(),
+            py_message.as_bytes(),
+        ]
+
+        for child_message in cases:
+            with self.subTest(child_type=child_message.__class__):
+                email = EmailMessage("parent message", "parent body")
+                email.attach(content=child_message, mimetype="message/rfc822")
+                self.assertEqual(len(email.attachments), 1)
+                self.assertIsInstance(email.attachments[0], EmailAttachment)
+                self.assertEqual(email.attachments[0].mimetype, "message/rfc822")
+
+                # Make sure it is serialized correctly: a message/rfc822 attachment
+                # whose "body" content (payload) is the "encapsulated" (child) message.
+                attachments = self.get_raw_attachments(email)
+                self.assertEqual(len(attachments), 1)
+                rfc822_attachment = attachments[0]
+                self.assertEqual(rfc822_attachment.get_content_type(), "message/rfc822")
+
+                attached_message = rfc822_attachment.get_content()
+                self.assertEqual(attached_message["Subject"], "child subject")
+                self.assertEqual(attached_message.get_content().rstrip(), "child body")
+
+                # Regression for #18967: Per RFC 2046 5.2.1, "No encoding other
+                # than '7bit', '8bit', or 'binary' is permitted for the body of
+                # a 'message/rfc822' entity." (Default CTE is "7bit".)
+                cte = rfc822_attachment.get("Content-Transfer-Encoding", "7bit")
+                self.assertIn(cte, ("7bit", "8bit", "binary"))
+
+                # Any properly declared CTE is allowed for the attached message itself
+                # (including quoted-printable or base64). For the plain ASCII content
+                # in this test, we'd expect 7bit.
+                child_cte = attached_message.get("Content-Transfer-Encoding", "7bit")
+                self.assertEqual(child_cte, "7bit")
+                self.assertEqual(attached_message.get_content_type(), "text/plain")
+
     def test_attach_mimebase_prohibits_other_params(self):
         email_msg = EmailMessage()
         txt = MIMEText("content")
@@ -1039,62 +1168,8 @@ class MailTests(MailTestsMixin, SimpleTestCase):
         s = msg.message().as_string()
         self.assertIn("Content-Transfer-Encoding: 8bit", s)
 
-    def test_dont_base64_encode_message_rfc822(self):
-        # Ticket #18967
-        # Shouldn't use base64 encoding for a child EmailMessage attachment.
-        # Create a child message first
-        child_msg = EmailMessage(
-            "Child Subject",
-            "Some body of child message",
-            "bounce@example.com",
-            ["to@example.com"],
-            headers={"From": "from@example.com"},
-        )
-        child_s = child_msg.message().as_string()
-
-        # Now create a parent
-        parent_msg = EmailMessage(
-            "Parent Subject",
-            "Some parent body",
-            "bounce@example.com",
-            ["to@example.com"],
-            headers={"From": "from@example.com"},
-        )
-
-        # Attach to parent as a string
-        parent_msg.attach(content=child_s, mimetype="message/rfc822")
-        parent_s = parent_msg.message().as_string()
-
-        # The child message header is not base64 encoded
-        self.assertIn("Child Subject", parent_s)
-
-        # Feature test: try attaching email.Message object directly to the mail.
-        parent_msg = EmailMessage(
-            "Parent Subject",
-            "Some parent body",
-            "bounce@example.com",
-            ["to@example.com"],
-            headers={"From": "from@example.com"},
-        )
-        parent_msg.attach(content=child_msg.message(), mimetype="message/rfc822")
-        parent_s = parent_msg.message().as_string()
-
-        # The child message header is not base64 encoded
-        self.assertIn("Child Subject", parent_s)
-
-        # Feature test: try attaching Django's EmailMessage object directly to the mail.
-        parent_msg = EmailMessage(
-            "Parent Subject",
-            "Some parent body",
-            "bounce@example.com",
-            ["to@example.com"],
-            headers={"From": "from@example.com"},
-        )
-        parent_msg.attach(content=child_msg, mimetype="message/rfc822")
-        parent_s = parent_msg.message().as_string()
-
-        # The child message header is not base64 encoded
-        self.assertIn("Child Subject", parent_s)
+    # (test_dont_base64_encode_message_rfc822() is now covered
+    # as part of test_attach_rfc822_message() above.)
 
     def test_custom_utf8_encoding(self):
         """A UTF-8 charset with a custom body encoding is respected."""
@@ -1239,6 +1314,121 @@ class MailTests(MailTestsMixin, SimpleTestCase):
         with self.assertRaisesMessage(ValueError, msg):
             email_msg.attach_alternative("<p>content</p>", None)
 
+    def test_mime_structure(self):
+        """
+        Check generated messages have the expected MIME parts and nesting.
+        """
+        html_body = EmailAlternative("<p>HTML</p>", "text/html")
+        image = EmailAttachment("image.gif", b"\x89PNG...", "image/png")
+        rfc822_attachment = EmailAttachment(
+            None, EmailMessage(body="text"), "message/rfc822"
+        )
+        cases = [
+            # name, email (EmailMessage or subclass), expected structure
+            (
+                "single body",
+                EmailMessage(body="text"),
+                """
+                text/plain
+                """,
+            ),
+            (
+                "single body with attachment",
+                EmailMessage(body="text", attachments=[image]),
+                """
+                multipart/mixed
+                    text/plain
+                    image/png
+                """,
+            ),
+            (
+                "alternative bodies",
+                EmailMultiAlternatives(body="text", alternatives=[html_body]),
+                """
+                multipart/alternative
+                    text/plain
+                    text/html
+                """,
+            ),
+            (
+                "alternative bodies with attachments",
+                EmailMultiAlternatives(
+                    body="text", alternatives=[html_body], attachments=[image]
+                ),
+                """
+                multipart/mixed
+                    multipart/alternative
+                        text/plain
+                        text/html
+                    image/png
+                """,
+            ),
+            (
+                "alternative bodies with rfc822 attachment",
+                EmailMultiAlternatives(
+                    body="text",
+                    alternatives=[html_body],
+                    attachments=[rfc822_attachment],
+                ),
+                """
+                multipart/mixed
+                    multipart/alternative
+                        text/plain
+                        text/html
+                    message/rfc822
+                        text/plain
+                """,
+            ),
+            (
+                "attachment only",
+                EmailMessage(attachments=[image]),
+                # Avoid empty text/plain body.
+                """
+                multipart/mixed
+                    image/png
+                """,
+            ),
+            (
+                "alternative only",
+                EmailMultiAlternatives(alternatives=[html_body]),
+                # Avoid empty text/plain body.
+                """
+                multipart/alternative
+                    text/html
+                """,
+            ),
+            (
+                "alternative and attachment only",
+                EmailMultiAlternatives(alternatives=[html_body], attachments=[image]),
+                """
+                multipart/mixed
+                    multipart/alternative
+                        text/html
+                    image/png
+                """,
+            ),
+            (
+                "empty EmailMessage",
+                EmailMessage(),
+                """
+                text/plain
+                """,
+            ),
+            (
+                "empty EmailMultiAlternatives",
+                EmailMultiAlternatives(),
+                """
+                text/plain
+                """,
+            ),
+        ]
+        for name, email, expected in cases:
+            expected = dedent(expected).lstrip()
+            with self.subTest(name=name):
+                message = email.message()
+                structure = self.get_message_structure(message)
+                self.assertEqual(structure, expected)
+
     def test_body_contains(self):
         email_msg = EmailMultiAlternatives()
         email_msg.body = "I am content."
@@ -1256,6 +1446,114 @@ class MailTests(MailTestsMixin, SimpleTestCase):
         email_msg.attach_alternative("I am content.", "text/html")
         email_msg.attach_alternative(b"I am a song.", "audio/mpeg")
         self.assertIs(email_msg.body_contains("I am content"), True)
+
+    def test_all_params_optional(self):
+        """
+        EmailMessage class docs: "All parameters are optional"
+        """
+        email = EmailMessage()
+        self.assertIsInstance(email.message(), PyMessage)  # force serialization
+
+        email = EmailMultiAlternatives()
+        self.assertIsInstance(email.message(), PyMessage)  # force serialization
+
+    def test_positional_arguments_order(self):
+        """
+        EmailMessage class docs: "… is initialized with the following parameters
+        (in the given order, if positional arguments are used)."
+        """
+        connection = mail.get_connection()
+        email = EmailMessage(
+            # (If you need to insert/remove/reorder any params here,
+            # that indicates a breaking change to documented behavior.)
+            "subject",
+            "body",
+            "from@example.com",
+            ["to@example.com"],
+            ["bcc@example.com"],
+            connection,
+            [EmailAttachment("file.txt", "attachment", "text/plain")],
+            {"X-Header": "custom header"},
+            ["cc@example.com"],
+            ["reply-to@example.com"],
+            # (New options can be added below here, ideally as keyword-only args.)
+        )
+
+        message = email.message()
+        self.assertEqual(message.get_all("Subject"), ["subject"])
+        self.assertEqual(message.get_all("From"), ["from@example.com"])
+        self.assertEqual(message.get_all("To"), ["to@example.com"])
+        self.assertEqual(message.get_all("X-Header"), ["custom header"])
+        self.assertEqual(message.get_all("Cc"), ["cc@example.com"])
+        self.assertEqual(message.get_all("Reply-To"), ["reply-to@example.com"])
+        self.assertEqual(message.get_payload(0).get_payload(), "body")
+        self.assertEqual(
+            self.get_decoded_attachments(email),
+            [("file.txt", "attachment", "text/plain")],
+        )
+        self.assertEqual(
+            email.recipients(), ["to@example.com", "cc@example.com", "bcc@example.com"]
+        )
+        self.assertIs(email.get_connection(), connection)
+
+    def test_all_params_can_be_set_before_send(self):
+        """
+        EmailMessage class docs: "All parameters … can be set at any time
+        prior to calling the send() method."
+        """
+        # This is meant to verify EmailMessage.__init__() doesn't apply any
+        # special processing that would be missing for properties set later.
+        original_connection = mail.get_connection(username="original")
+        new_connection = mail.get_connection(username="new")
+        email = EmailMessage(
+            "original subject",
+            "original body",
+            "original-from@example.com",
+            ["original-to@example.com"],
+            ["original-bcc@example.com"],
+            original_connection,
+            [EmailAttachment("original.txt", "original attachment", "text/plain")],
+            {"X-Header": "original header"},
+            ["original-cc@example.com"],
+            ["original-reply-to@example.com"],
+        )
+        email.subject = "new subject"
+        email.body = "new body"
+        email.from_email = "new-from@example.com"
+        email.to = ["new-to@example.com"]
+        email.bcc = ["new-bcc@example.com"]
+        email.connection = new_connection
+        email.attachments = [
+            ("new1.txt", "new attachment 1", "text/plain"),  # plain tuple
+            EmailAttachment("new2.txt", "new attachment 2", "text/csv"),
+            MIMEImage(b"GIF89a...", "gif"),
+        ]
+        email.extra_headers = {"X-Header": "new header"}
+        email.cc = ["new-cc@example.com"]
+        email.reply_to = ["new-reply-to@example.com"]
+
+        message = email.message()
+        self.assertEqual(message.get_all("Subject"), ["new subject"])
+        self.assertEqual(message.get_all("From"), ["new-from@example.com"])
+        self.assertEqual(message.get_all("To"), ["new-to@example.com"])
+        self.assertEqual(message.get_all("X-Header"), ["new header"])
+        self.assertEqual(message.get_all("Cc"), ["new-cc@example.com"])
+        self.assertEqual(message.get_all("Reply-To"), ["new-reply-to@example.com"])
+        self.assertEqual(message.get_payload(0).get_payload(), "new body")
+        self.assertEqual(
+            self.get_decoded_attachments(email),
+            [
+                ("new1.txt", "new attachment 1", "text/plain"),
+                ("new2.txt", "new attachment 2", "text/csv"),
+                (None, b"GIF89a...", "image/gif"),
+            ],
+        )
+        self.assertEqual(
+            email.recipients(),
+            ["new-to@example.com", "new-cc@example.com", "new-bcc@example.com"],
+        )
+        self.assertIs(email.get_connection(), new_connection)
+        self.assertNotIn("original", message.as_string())
 
 
 @requires_tz_support
@@ -1806,6 +2104,7 @@ class ConsoleBackendTests(BaseEmailBackendTests, SimpleTestCase):
 class SMTPHandler:
     def __init__(self, *args, **kwargs):
         self.mailbox = []
+        self.smtp_envelopes = []
 
     async def handle_DATA(self, server, session, envelope):
         data = envelope.content
@@ -1820,10 +2119,17 @@ class SMTPHandler:
         if mail_from != header_from:
             return f"553 '{mail_from}' != '{header_from}'"
         self.mailbox.append(message)
+        self.smtp_envelopes.append(
+            {
+                "mail_from": envelope.mail_from,
+                "rcpt_tos": envelope.rcpt_tos,
+            }
+        )
         return "250 OK"
 
     def flush_mailbox(self):
         self.mailbox[:] = []
+        self.smtp_envelopes[:] = []
 
 
 @skipUnless(HAS_AIOSMTPD, "No aiosmtpd library detected.")
@@ -1869,6 +2175,9 @@ class SMTPBackendTests(BaseEmailBackendTests, SMTPBackendTestsBase):
 
     def get_mailbox_content(self):
         return self.smtp_handler.mailbox
+
+    def get_smtp_envelopes(self):
+        return self.smtp_handler.smtp_envelopes
 
     @override_settings(
         EMAIL_HOST_USER="not empty username",
@@ -2093,6 +2402,85 @@ class SMTPBackendTests(BaseEmailBackendTests, SMTPBackendTestsBase):
         email = EmailMessage("Subject", "Content", "from@example.com", to=[])
         sent = backend.send_messages([email])
         self.assertEqual(sent, 0)
+
+    def test_avoids_sending_to_invalid_addresses(self):
+        """
+        Verify invalid addresses can't sneak into SMTP commands through
+        EmailMessage.all_recipients() (which is distinct from message header fields).
+        """
+        backend = smtp.EmailBackend()
+        backend.connection = mock.Mock()
+        for email_address in (
+            # Invalid address with two @ signs.
+            "to@other.com@example.com",
+            # Invalid address without the quotes.
+            "to@other.com <to@example.com>",
+            # Other invalid addresses.
+            "@",
+            "to@",
+            "@example.com",
+            # CR/NL in addr-spec. (SMTP strips display-name.)
+            '"evil@example.com\r\nto"@example.com',
+            "to\nevil@example.com",
+        ):
+            with self.subTest(email_address=email_address):
+                # Use bcc (which is only processed by SMTP backend) to ensure
+                # error is coming from SMTP backend, not EmailMessage.message().
+                email = EmailMessage(bcc=[email_address])
+                with self.assertRaisesMessage(ValueError, "Invalid address"):
+                    backend.send_messages([email])
+
+    def test_encodes_idna_in_smtp_commands(self):
+        """
+        SMTP backend must encode non-ASCII domains for the SMTP envelope
+        (which can be distinct from the email headers).
+        """
+        email = EmailMessage(
+            from_email="lists@discussão.example.org",
+            to=["To Example <to@漢字.example.com>"],
+            bcc=["monitor@discussão.example.org"],
+            headers={
+                "From": "Gestor de listas <lists@discussão.example.org>",
+                "To": "Discussão Django <django@discussão.example.org>",
+            },
+        )
+        backend = smtp.EmailBackend()
+        backend.send_messages([email])
+        envelope = self.get_smtp_envelopes()[0]
+        self.assertEqual(envelope["mail_from"], "lists@xn--discusso-xza.example.org")
+        self.assertEqual(
+            envelope["rcpt_tos"],
+            ["to@xn--p8s937b.example.com", "monitor@xn--discusso-xza.example.org"],
+        )
+
+    def test_does_not_reencode_idna(self):
+        """
+        SMTP backend should not downgrade IDNA 2008 to IDNA 2003.
+
+        Django does not currently handle IDNA 2008 encoding, but should retain
+        it for addresses that have been pre-encoded.
+        """
+        # Test all four EmailMessage attrs accessed by the SMTP email backend.
+        # These are IDNA 2008 encoded domains that would be different
+        # in IDNA 2003, from https://www.unicode.org/reports/tr46/#Deviations.
+        email = EmailMessage(
+            from_email='"βόλος" <from@xn--fa-hia.example.com>',
+            to=['"faß" <to@xn--10cl1a0b660p.example.com>'],
+            cc=['"ශ්‍රී" <cc@xn--nxasmm1c.example.com>'],
+            bcc=['"نامه‌ای." <bcc@xn--mgba3gch31f060k.example.com>'],
+        )
+        backend = smtp.EmailBackend()
+        backend.send_messages([email])
+        envelope = self.get_smtp_envelopes()[0]
+        self.assertEqual(envelope["mail_from"], "from@xn--fa-hia.example.com")
+        self.assertEqual(
+            envelope["rcpt_tos"],
+            [
+                "to@xn--10cl1a0b660p.example.com",
+                "cc@xn--nxasmm1c.example.com",
+                "bcc@xn--mgba3gch31f060k.example.com",
+            ],
+        )
 
 
 @skipUnless(HAS_AIOSMTPD, "No aiosmtpd library detected.")

--- a/tests/mail/tests.py
+++ b/tests/mail/tests.py
@@ -1,5 +1,6 @@
 import mimetypes
 import os
+import re
 import shutil
 import socket
 import sys
@@ -7,6 +8,7 @@ import tempfile
 from email import charset, message_from_binary_file
 from email import message_from_bytes as _message_from_bytes
 from email import policy
+from email.headerregistry import Address
 from email.message import EmailMessage as PyEmailMessage
 from email.message import Message as PyMessage
 from email.mime.image import MIMEImage
@@ -193,8 +195,11 @@ class MailTests(MailTestsMixin, SimpleTestCase):
         same error handling strategy to avoid errors such as:
 
         UnicodeEncodeError: 'utf-8' codec can't encode <...>: surrogates not allowed
-
         """
+
+        # This test is specific to Python's legacy MIMEText, and can be safely removed
+        # if EmailMessage.message() switches Python's modern email API.
+        # Using surrogateescape for non-utf8 is already covered in test_encoding().
 
         def simplified_set_payload(instance, payload, charset):
             instance._payload = payload
@@ -419,16 +424,17 @@ class MailTests(MailTestsMixin, SimpleTestCase):
         """
         email = EmailMessage(
             "Long subject lines that get wrapped should contain a space continuation "
-            "character to get expected behavior in Outlook and Thunderbird",
-            "Content",
-            "from@example.com",
-            ["to@example.com"],
+            "character to comply with RFC 822",
         )
         message = email.message()
-        self.assertEqual(
-            message["Subject"].encode(),
-            b"Long subject lines that get wrapped should contain a space continuation\n"
-            b" character to get expected behavior in Outlook and Thunderbird",
+        msg_bytes = message.as_bytes()
+        # Python's legacy email wraps this more than strictly necessary
+        # (but uses FWS properly at each wrap). Modern email wraps it better.
+        self.assertIn(
+            b"Subject: Long subject lines that get wrapped should contain a space\n"
+            b" continuation\n"
+            b" character to comply with RFC 822",
+            msg_bytes,
         )
 
     def test_message_header_overrides(self):
@@ -532,17 +538,25 @@ class MailTests(MailTestsMixin, SimpleTestCase):
         email = EmailMessage(
             to=['"Firstname Sürname" <to@example.com>', "other@example.com"],
         )
+        reparsed = message_from_bytes(email.message().as_bytes())
         self.assertEqual(
-            email.message()["To"],
-            "=?utf-8?q?Firstname_S=C3=BCrname?= <to@example.com>, other@example.com",
+            reparsed["To"].addresses,
+            (
+                Address(display_name="Firstname Sürname", addr_spec="to@example.com"),
+                Address(addr_spec="other@example.com"),
+            ),
         )
 
         email = EmailMessage(
             to=['"Sürname, Firstname" <to@example.com>', "other@example.com"],
         )
+        reparsed = message_from_bytes(email.message().as_bytes())
         self.assertEqual(
-            email.message()["To"],
-            "=?utf-8?q?S=C3=BCrname=2C_Firstname?= <to@example.com>, other@example.com",
+            reparsed["To"].addresses,
+            (
+                Address(display_name="Sürname, Firstname", addr_spec="to@example.com"),
+                Address(addr_spec="other@example.com"),
+            ),
         )
 
     def test_unicode_headers(self):
@@ -555,13 +569,24 @@ class MailTests(MailTestsMixin, SimpleTestCase):
             },
         )
         message = email.message()
-        self.assertEqual(message["Subject"], "=?utf-8?b?R8W8ZWfFvMOzxYJrYQ==?=")
-        self.assertEqual(
-            message["Sender"], "=?utf-8?q?Firstname_S=C3=BCrname?= <sender@example.com>"
+
+        # Verify sent headers use RFC 2047 encoded-words.
+        msg_bytes = message.as_bytes()
+        self.assertIn(b"Subject: =?utf-8?b?R8W8ZWfFvMOzxYJrYQ==?=", msg_bytes)
+        self.assertIn(
+            b"Sender: =?utf-8?q?Firstname_S=C3=BCrname?= <sender@example.com>",
+            msg_bytes,
         )
+        self.assertIn(b"Comments: =?utf-8?q?My_S=C3=BCrname_is_non-ASCII?=", msg_bytes)
+
+        # Verify sent headers parse to original values.
+        reparsed = message_from_bytes(msg_bytes)
+        self.assertEqual(reparsed["Subject"], "Gżegżółka")
         self.assertEqual(
-            message["Comments"], "=?utf-8?q?My_S=C3=BCrname_is_non-ASCII?="
+            reparsed["Sender"].address,
+            Address(display_name="Firstname Sürname", addr_spec="sender@example.com"),
         )
+        self.assertEqual(reparsed["Comments"], "My Sürname is non-ASCII")
 
     def test_non_utf8_headers_multipart(self):
         """
@@ -573,22 +598,32 @@ class MailTests(MailTestsMixin, SimpleTestCase):
         to = '"Sürname, Firstname" <to@example.com>'
         text_content = "This is an important message."
         html_content = "<p>This is an <strong>important</strong> message.</p>"
-        msg = EmailMultiAlternatives(
+        email = EmailMultiAlternatives(
             "Message from Firstname Sürname",
             text_content,
             from_email,
             [to],
             headers=headers,
         )
-        msg.attach_alternative(html_content, "text/html")
-        msg.encoding = "iso-8859-1"
-        self.assertEqual(
-            msg.message()["To"],
-            "=?iso-8859-1?q?S=FCrname=2C_Firstname?= <to@example.com>",
+        email.attach_alternative(html_content, "text/html")
+        email.encoding = "iso-8859-1"
+        message = email.message()
+
+        # Verify sent headers use RFC 2047 encoded-words.
+        msg_bytes = message.as_bytes()
+        self.assertIn(
+            b"To: =?iso-8859-1?q?S=FCrname=2C_Firstname?= <to@example.com>", msg_bytes
         )
+        self.assertIn(
+            b"Subject: =?iso-8859-1?q?Message_from_Firstname_S=FCrname?=", msg_bytes
+        )
+
+        # Verify sent headers parse to original values.
+        reparsed = message_from_bytes(msg_bytes)
+        self.assertEqual(reparsed["Subject"], "Message from Firstname Sürname")
         self.assertEqual(
-            msg.message()["Subject"],
-            "=?iso-8859-1?q?Message_from_Firstname_S=FCrname?=",
+            reparsed["To"].addresses,
+            (Address(display_name="Sürname, Firstname", addr_spec="to@example.com"),),
         )
 
     def test_multipart_with_attachments(self):
@@ -697,9 +732,6 @@ class MailTests(MailTestsMixin, SimpleTestCase):
         self.assertMessageHasHeaders(
             payload0,
             {
-                # (The MIME-Version header is neither required nor meaningful
-                # in a subpart, and this check for it can be safely removed.)
-                ("MIME-Version", "1.0"),
                 ("Content-Type", 'text/plain; charset="iso-8859-1"'),
                 ("Content-Transfer-Encoding", "quoted-printable"),
             },
@@ -712,9 +744,6 @@ class MailTests(MailTestsMixin, SimpleTestCase):
         self.assertMessageHasHeaders(
             payload1,
             {
-                # (The MIME-Version header is neither required nor meaningful
-                # in a subpart, and this check for it can be safely removed.)
-                ("MIME-Version", "1.0"),
                 ("Content-Type", 'text/html; charset="iso-8859-1"'),
                 ("Content-Transfer-Encoding", "quoted-printable"),
             },
@@ -1145,11 +1174,6 @@ class MailTests(MailTestsMixin, SimpleTestCase):
         msg = EmailMessage(body="Body with latin characters: àáä.")
         s = msg.message().as_bytes()
         self.assertIn(b"Content-Transfer-Encoding: 8bit", s)
-        # The following test is left over from Python 2 and can be safely removed.
-        # 8bit CTE within a Unicode str is not meaningful, and Python's modern
-        # email api won't generate it. (The test still works with the legacy api.)
-        s = msg.message().as_string()
-        self.assertIn("Content-Transfer-Encoding: 8bit", s)
 
         # Long body lines that require folding should use quoted-printable or base64,
         # whichever is shorter. However, Python's legacy email API avoids re-folding
@@ -1164,9 +1188,6 @@ class MailTests(MailTestsMixin, SimpleTestCase):
         )
         s = msg.message().as_bytes()
         self.assertIn(b"Content-Transfer-Encoding: 8bit", s)
-        # The following test is left over from Python 2.
-        s = msg.message().as_string()
-        self.assertIn("Content-Transfer-Encoding: 8bit", s)
 
     # (test_dont_base64_encode_message_rfc822() is now covered
     # as part of test_attach_rfc822_message() above.)
@@ -1191,6 +1212,9 @@ class MailTests(MailTestsMixin, SimpleTestCase):
 
     def test_sanitize_address(self):
         """Email addresses are properly sanitized."""
+        # This is a unit test for the internal sanitize_address() function.
+        # Many of these cases are now duplicated in test_address_header_encoding(),
+        # which verifies headers in the generated message.
         for email_address, encoding, expected_result in (
             # ASCII addresses.
             ("to@example.com", "ascii", "to@example.com"),
@@ -1278,6 +1302,11 @@ class MailTests(MailTestsMixin, SimpleTestCase):
                 )
 
     def test_sanitize_address_invalid(self):
+        # This is a unit test for the internal sanitize_address() function.
+        # Note that Django's EmailMessage.message() will _not_ catch these cases,
+        # as it only calls sanitize_address() if an address also includes non-ASCII
+        # chars. Django detects these cases in the SMTP EmailBackend during sending.
+        # See SMTPBackendTests.test_avoids_sending_to_invalid_addresses() below.
         for email_address in (
             # Invalid address with two @ signs.
             "to@other.com@example.com",
@@ -1294,6 +1323,9 @@ class MailTests(MailTestsMixin, SimpleTestCase):
                     sanitize_address(email_address, encoding="utf-8")
 
     def test_sanitize_address_header_injection(self):
+        # This is a unit test for the internal sanitize_address() function.
+        # These cases are also duplicated in test_address_header_encoding(),
+        # which verifies headers in the generated message.
         msg = "Invalid address; address parts cannot contain newlines."
         tests = [
             "Name\nInjection <to@example.com>",
@@ -1305,6 +1337,114 @@ class MailTests(MailTestsMixin, SimpleTestCase):
             with self.subTest(email_address=email_address):
                 with self.assertRaisesMessage(ValueError, msg):
                     sanitize_address(email_address, encoding="utf-8")
+
+    def test_address_header_encoding(self):
+        # This verifies the modern email API's address header handling.
+        # (Adapted from older test_sanitize_address() for legacy email API.)
+        cases = [
+            # (address, expected)
+            ("to@example.com", "to@example.com"),
+            ("localpartonly", "localpartonly"),
+            # Addresses with display-names.
+            ("A name <to@example.com>", "A name <to@example.com>"),
+            ('"A name" <to@example.com>', '"A name" <to@example.com>'),
+            (
+                '"Comma, requires quotes" <to@example.com>',
+                '"Comma, requires quotes" <to@example.com>',
+            ),
+            ('"to@other.com" <to@example.com>', '"to@other.com" <to@example.com>'),
+            # Non-ASCII addr-spec: IDNA encoding for domain.
+            # (Note: no RFC permits encoding a non-ASCII localpart.)
+            ("to@éxample.com", "to@xn--xample-9ua.com"),
+            (
+                "To Example <to@éxample.com>",
+                "To Example <to@xn--xample-9ua.com>",
+            ),
+            # Pre-encoded IDNA domain is left as is.
+            # (Make sure IDNA 2008 is not downgraded to IDNA 2003.)
+            ("to@xn--fa-hia.example.com", "to@xn--fa-hia.example.com"),
+            ("<to@xn--10cl1a0b660p.example.com>", "<to@xn--10cl1a0b660p.example.com>"),
+            (
+                '"Display, Name" <to@xn--nxasmm1c.example.com>',
+                '"Display, Name" <to@xn--nxasmm1c.example.com>',
+            ),
+            # Non-ASCII display-name as RFC-2047 encoded-word.
+            (
+                "Tó Example <to@example.com>",
+                "=?utf-8?q?T=C3=B3_Example?= <to@example.com>",
+            ),
+            # Addresses with two @ signs (quoted-string localpart).
+            ('"to@other.com"@example.com', '"to@other.com"@example.com'),
+            (
+                'To Example <"to@other.com"@example.com>',
+                'To Example <"to@other.com"@example.com>',
+            ),
+            # Addresses with long non-ASCII display names.
+            (
+                "Tó Example very long" * 4 + " <to@example.com>",
+                "=?utf-8?q?T=C3=B3_Example_very_longT=C3=B3_Example_very_longT"
+                "=C3=B3_Example_?="
+                " =?utf-8?q?very_longT=C3=B3_Example_very_long?= <to@example.com>",
+            ),
+            # Address with long display name and non-ASCII domain.
+            (
+                "To Example very long" * 4 + " <to@exampl€.com>",
+                "To Example very longTo Example very longTo Example very lo"
+                "ngTo Example very long <to@xn--exampl-nc1c.com>",
+            ),
+        ]
+        for address, expected in cases:
+            with self.subTest(address=address):
+                email = EmailMessage(to=[address])
+                actual = email.message().as_bytes().decode()
+                # Unfold FWS and extract the To header. (This is not even close
+                # to a complete header parser, but is sufficient for this test.
+                # Note it does not recombine adjacent/folded RFC 2047 encoded-words.)
+                headers = re.sub(r"\s*\r?\n ", " ", actual).splitlines()
+                to_header = [h for h in headers if h.startswith("To:")][0]
+                expected_header = f"To: {expected}"
+                self.assertEqual(to_header, expected_header)
+
+    def test_address_header_injection(self):
+        # (This error message comes from Django's internal forbid_multi_line_headers().)
+        msg = "Header values can't contain newlines"
+        cases = [
+            "Name\nInjection <to@example.com>",
+            '"Name\nInjection" <to@example.com>',
+            '"Name\rInjection" <to@example.com>',
+            '"Name\r\nInjection" <to@example.com>',
+            "Name <to\ninjection@example.com>",
+            "to\ninjection@example.com",
+        ]
+
+        # Structured address header fields (from RFC 5322 3.6.x).
+        headers = [
+            "From",
+            "Sender",
+            "Reply-To",
+            "To",
+            "Cc",
+            # "Bcc" is not checked by EmailMessage.message().
+            # (See SMTPBackendTests.test_avoids_sending_to_invalid_addresses().)
+            "Resent-From",
+            "Resent-Sender",
+            "Resent-To",
+            "Resent-Cc",
+            "Resent-Bcc",
+        ]
+
+        for header in headers:
+            for email_address in cases:
+                with self.subTest(header=header, email_address=email_address):
+                    if header == "From":
+                        email = EmailMessage(from_email=email_address)
+                    elif header in ("To", "Cc", "Bcc", "Reply-To"):
+                        param = header.lower().replace("-", "_")
+                        email = EmailMessage(**{param: [email_address]})
+                    else:
+                        email = EmailMessage(headers={header: email_address})
+                    with self.assertRaisesMessage(ValueError, msg):
+                        email.message()
 
     def test_email_multi_alternatives_content_mimetype_none(self):
         email_msg = EmailMultiAlternatives()


### PR DESCRIPTION
#### Trac ticket number

ticket-35581

#### Branch description

Switch django.core.mail from Python's "legacy email API" to its newer "modern email API."

**DO NOT MERGE** until these security issues in Python's modern email API have been fixed: python/cpython#80222 and python/cpython#121284.


#### Checklist
- [ ] This PR targets the `main` branch.
   [This PR currently targets django/django#18502]
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [x] I have added or updated relevant docs, including release notes if applicable.
- n/a I have attached screenshots in both light and dark modes for any UI changes.

#### Notes

This is the second of two PRs involved in updating django.core.mail from Python's legacy to modern email APIs. See django/django#18502 for a separate PR that expands existing email tests prior to these changes.

Some info that may be helpful for reviewers:

1. **Forced trailing newlines in text parts:** Python's modern email API forces trailing newlines on text/* content in message bodies and attachments (see python/cpython#121515). In practice, this probably doesn't matter much: most text/* content ends with a newline, and it generally doesn't hurt to add one. 
 
   Unfortunately, *a lot* of our test cases used variations on `body="Content"` and `assertEqual(generated_body, "Content")` without trailing newlines. Modern email's behavior _broke all of these tests_. I've updated them to include trailing newlines (in both fixture and assertion).

   I'm open to suggestions on this. I did investigate some workarounds for handling the body encoding ourselves, but these either had other downsides (e.g., sending all text/* content with base64 content transfer encoding) or involved copying [a big chunk of Python's `raw_content_manager` implementation](https://github.com/python/cpython/blob/v3.12.5/Lib/email/contentmanager.py#L144-L194) into Django's code, which kind of goes against the spirit of this ticket.

2. **MIMEBase attachments:** I had [originally proposed continuing support for MIMEBase attachments](https://groups.google.com/g/django-developers/c/2zf9GQtjdIk/m/LcBfqfizAAAJ) without deprecation. But it turns out modern email's `email.message.MIMEPart` is a good replacement, so this PR puts MIMEBase on the usual deprecation path. I've also added a docs example of using MIMEPart for inline images.

3. **Deprecations and changes to undocumented behavior:**
   * Implemented the [deprecation plan from the original django-developers discussion](https://groups.google.com/g/django-developers/c/2zf9GQtjdIk).
   * Removed support for the undocumented `EmailMessage.mixed_subtype` and `EmailMultiAlternatives.alternative_subtype` attributes. (But it will raise an error on attempts to use them.)
   * Removed undocumented support for legacy `email.charset.Charset` objects in the undocumented `EmailMessage.encoding` property. (There was a single test that covered this; it's been removed.)
   * Otherwise preserved support for the undocumented `EmailMessage.encoding` property. I suggest renaming this to `charset` if we ever want to document it.

4. **Changes to RFC 2047 encoded-words in non-ASCII headers:**

   * Modern email uses a different RFC 2047 encoder than legacy. The results are semantically equivalent, but modern email tries to minimize the portion of the header using RFC 2047 encoding. This affected several test cases that were looking for a specific encoded-word in the generated message.
   * Modern email supports *only* the utf-8 charset for generating RFC 2047 encoded-words. With legacy email, Django used the `DEFAULT_CHARSET` setting (or the undocumented `EmailMessage.encoding` override) to set the encoded-word charset. The results are semantically equivalent, but this affected one test case. (In practice, it seems extremely unlikely there would be email software still in use that supports RFC 2047 encoding but doesn't understand utf-8.)
   * I dropped *tests* for applying RFC 2047 encoding to the localpart ("username") of a non-ASCII email address. RFC 2047 specifically prohibits this, and no known MTA or email client supports it. See [ticket-25986#12](https://code.djangoproject.com/ticket/25986#comment:12) et seq. (Python will actually still incorrectly use an encoded-word here, but [it's a Python bug](https://github.com/python/cpython/issues/81074#issuecomment-1093823543) that [might get fixed](https://github.com/python/cpython/pull/122540) someday, so I'm no longer testing for it.)
